### PR TITLE
Fix links in venues non reg table

### DIFF
--- a/docs/venues/index.html
+++ b/docs/venues/index.html
@@ -190,7 +190,7 @@ venues</h3>
 <tbody>
 <tr class="odd">
 <td align="left"><a
-href="https://codecheck.org.uk/register/venues/journal/">Journal</a></td>
+href="https://codecheck.org.uk/register/venues/journals/">Journal</a></td>
 <td align="left"><a
 href="https://codecheck.org.uk/register/venues/journal/gigascience/">GigaScience</a></td>
 <td align="left">2 <a
@@ -199,7 +199,7 @@ all checks)</a></td>
 </tr>
 <tr class="even">
 <td align="left"><a
-href="https://codecheck.org.uk/register/venues/community/">Community</a></td>
+href="https://codecheck.org.uk/register/venues/communities/">Community</a></td>
 <td align="left"><a
 href="https://codecheck.org.uk/register/venues/community/codecheck/">CODECHECK</a></td>
 <td align="left">8 <a
@@ -208,7 +208,7 @@ all checks)</a></td>
 </tr>
 <tr class="odd">
 <td align="left"><a
-href="https://codecheck.org.uk/register/venues/community/">Community</a></td>
+href="https://codecheck.org.uk/register/venues/communities/">Community</a></td>
 <td align="left"><a
 href="https://codecheck.org.uk/register/venues/community/preprint/">Preprint</a></td>
 <td align="left">9 <a
@@ -217,7 +217,7 @@ all checks)</a></td>
 </tr>
 <tr class="even">
 <td align="left"><a
-href="https://codecheck.org.uk/register/venues/community/">Community</a></td>
+href="https://codecheck.org.uk/register/venues/communities/">Community</a></td>
 <td align="left"><a
 href="https://codecheck.org.uk/register/venues/community/in_press/">In
 press</a></td>
@@ -227,7 +227,7 @@ all checks)</a></td>
 </tr>
 <tr class="odd">
 <td align="left"><a
-href="https://codecheck.org.uk/register/venues/journal/">Journal</a></td>
+href="https://codecheck.org.uk/register/venues/journals/">Journal</a></td>
 <td align="left"><a
 href="https://codecheck.org.uk/register/venues/journal/j_geogr_syst/">Journal
 of Geographical Systems</a></td>
@@ -237,7 +237,7 @@ all checks)</a></td>
 </tr>
 <tr class="even">
 <td align="left"><a
-href="https://codecheck.org.uk/register/venues/conference/">Conference</a></td>
+href="https://codecheck.org.uk/register/venues/conferences/">Conference</a></td>
 <td align="left"><a
 href="https://codecheck.org.uk/register/venues/conference/agilegis/">AGILE
 Conference on Geographic Information Science</a></td>
@@ -247,7 +247,7 @@ all checks)</a></td>
 </tr>
 <tr class="odd">
 <td align="left"><a
-href="https://codecheck.org.uk/register/venues/journal/">Journal</a></td>
+href="https://codecheck.org.uk/register/venues/journals/">Journal</a></td>
 <td align="left"><a
 href="https://codecheck.org.uk/register/venues/journal/j_archaeol_sci/">Journal
 of Archaeological Science</a></td>
@@ -257,7 +257,7 @@ all checks)</a></td>
 </tr>
 <tr class="even">
 <td align="left"><a
-href="https://codecheck.org.uk/register/venues/journal/">Journal</a></td>
+href="https://codecheck.org.uk/register/venues/journals/">Journal</a></td>
 <td align="left"><a
 href="https://codecheck.org.uk/register/venues/journal/gigabyte/">GigaByte</a></td>
 <td align="left">1 <a
@@ -266,7 +266,7 @@ all checks)</a></td>
 </tr>
 <tr class="odd">
 <td align="left"><a
-href="https://codecheck.org.uk/register/venues/community/">Community</a></td>
+href="https://codecheck.org.uk/register/venues/communities/">Community</a></td>
 <td align="left"><a
 href="https://codecheck.org.uk/register/venues/community/codecheck_nl/">CODECHECK
 NL</a></td>
@@ -276,7 +276,7 @@ all checks)</a></td>
 </tr>
 <tr class="even">
 <td align="left"><a
-href="https://codecheck.org.uk/register/venues/community/">Community</a></td>
+href="https://codecheck.org.uk/register/venues/communities/">Community</a></td>
 <td align="left"><a
 href="https://codecheck.org.uk/register/venues/community/aumc/">Amsterdam
 UMC</a></td>


### PR DESCRIPTION
Something I missed in the previous PR: https://github.com/codecheckers/register/pull/112

The hyperlinks in the venues table still had URLs with singular venue types.
I fixed it in this PR.

