### PR TITLE
Fix hyperlinks postfix

### DIFF
--- a/docs/venues/communities/aumc/index.html
+++ b/docs/venues/communities/aumc/index.html
@@ -206,13 +206,13 @@ class="uri">https://doi.org/10.5281/zenodo.13364677</a></td>
 </table>
 
 <p style="margin-bottom: 2em;">
-    <a href="https://raw.githubusercontent.com/codecheckers/register/master/docs/venues/community/aumc/register.csv"
+    <a href="https://raw.githubusercontent.com/codecheckers/register/master/docs/venues/communities/aumc/register.csv"
         title="raw CSV of register">CSV source</a> | <a
-        href="https://github.com/codecheckers/register/blob/master/docs/venues/community/aumc/register.csv"
+        href="https://github.com/codecheckers/register/blob/master/docs/venues/communities/aumc/register.csv"
         title="searchable CSV on GitHub">searchable CSV</a> | <a
-        href="https://codecheck.org.uk/register/venues/community/aumc/register.json"
+        href="https://codecheck.org.uk/register/venues/communities/aumc/register.json"
         title="JSON export of register">JSON</a> | <a
-        href="https://codecheck.org.uk/register/venues/community/aumc/register.md"
+        href="https://codecheck.org.uk/register/venues/communities/aumc/register.md"
         title="Markdown rendering of register">Markdown</a>
 </p>
 

--- a/docs/venues/communities/aumc/index_postfix.html
+++ b/docs/venues/communities/aumc/index_postfix.html
@@ -1,11 +1,11 @@
 <p style="margin-bottom: 2em;">
-    <a href="https://raw.githubusercontent.com/codecheckers/register/master/docs/venues/community/aumc/register.csv"
+    <a href="https://raw.githubusercontent.com/codecheckers/register/master/docs/venues/communities/aumc/register.csv"
         title="raw CSV of register">CSV source</a> | <a
-        href="https://github.com/codecheckers/register/blob/master/docs/venues/community/aumc/register.csv"
+        href="https://github.com/codecheckers/register/blob/master/docs/venues/communities/aumc/register.csv"
         title="searchable CSV on GitHub">searchable CSV</a> | <a
-        href="https://codecheck.org.uk/register/venues/community/aumc/register.json"
+        href="https://codecheck.org.uk/register/venues/communities/aumc/register.json"
         title="JSON export of register">JSON</a> | <a
-        href="https://codecheck.org.uk/register/venues/community/aumc/register.md"
+        href="https://codecheck.org.uk/register/venues/communities/aumc/register.md"
         title="Markdown rendering of register">Markdown</a>
 </p>
 

--- a/docs/venues/communities/aumc/stats.json
+++ b/docs/venues/communities/aumc/stats.json
@@ -1,4 +1,4 @@
 {
-  "source": "https://codecheck.org.uk/register/venues/community/aumc/register.json",
+  "source": "https://codecheck.org.uk/register/venues/communities/aumc/register.json",
   "cert_count": 1
 }

--- a/docs/venues/communities/codecheck/index.html
+++ b/docs/venues/communities/codecheck/index.html
@@ -283,13 +283,13 @@ class="uri">https://doi.org/10.5281/zenodo.6040066</a></td>
 </table>
 
 <p style="margin-bottom: 2em;">
-    <a href="https://raw.githubusercontent.com/codecheckers/register/master/docs/venues/community/codecheck/register.csv"
+    <a href="https://raw.githubusercontent.com/codecheckers/register/master/docs/venues/communities/codecheck/register.csv"
         title="raw CSV of register">CSV source</a> | <a
-        href="https://github.com/codecheckers/register/blob/master/docs/venues/community/codecheck/register.csv"
+        href="https://github.com/codecheckers/register/blob/master/docs/venues/communities/codecheck/register.csv"
         title="searchable CSV on GitHub">searchable CSV</a> | <a
-        href="https://codecheck.org.uk/register/venues/community/codecheck/register.json"
+        href="https://codecheck.org.uk/register/venues/communities/codecheck/register.json"
         title="JSON export of register">JSON</a> | <a
-        href="https://codecheck.org.uk/register/venues/community/codecheck/register.md"
+        href="https://codecheck.org.uk/register/venues/communities/codecheck/register.md"
         title="Markdown rendering of register">Markdown</a>
 </p>
 

--- a/docs/venues/communities/codecheck/index_postfix.html
+++ b/docs/venues/communities/codecheck/index_postfix.html
@@ -1,11 +1,11 @@
 <p style="margin-bottom: 2em;">
-    <a href="https://raw.githubusercontent.com/codecheckers/register/master/docs/venues/community/codecheck/register.csv"
+    <a href="https://raw.githubusercontent.com/codecheckers/register/master/docs/venues/communities/codecheck/register.csv"
         title="raw CSV of register">CSV source</a> | <a
-        href="https://github.com/codecheckers/register/blob/master/docs/venues/community/codecheck/register.csv"
+        href="https://github.com/codecheckers/register/blob/master/docs/venues/communities/codecheck/register.csv"
         title="searchable CSV on GitHub">searchable CSV</a> | <a
-        href="https://codecheck.org.uk/register/venues/community/codecheck/register.json"
+        href="https://codecheck.org.uk/register/venues/communities/codecheck/register.json"
         title="JSON export of register">JSON</a> | <a
-        href="https://codecheck.org.uk/register/venues/community/codecheck/register.md"
+        href="https://codecheck.org.uk/register/venues/communities/codecheck/register.md"
         title="Markdown rendering of register">Markdown</a>
 </p>
 

--- a/docs/venues/communities/codecheck/stats.json
+++ b/docs/venues/communities/codecheck/stats.json
@@ -1,4 +1,4 @@
 {
-  "source": "https://codecheck.org.uk/register/venues/community/codecheck/register.json",
+  "source": "https://codecheck.org.uk/register/venues/communities/codecheck/register.json",
   "cert_count": 8
 }

--- a/docs/venues/communities/codecheck_nl/index.html
+++ b/docs/venues/communities/codecheck_nl/index.html
@@ -218,13 +218,13 @@ class="uri">https://doi.org/10.5281/zenodo.11403956</a></td>
 </table>
 
 <p style="margin-bottom: 2em;">
-    <a href="https://raw.githubusercontent.com/codecheckers/register/master/docs/venues/community/codecheck_nl/register.csv"
+    <a href="https://raw.githubusercontent.com/codecheckers/register/master/docs/venues/communities/codecheck_nl/register.csv"
         title="raw CSV of register">CSV source</a> | <a
-        href="https://github.com/codecheckers/register/blob/master/docs/venues/community/codecheck_nl/register.csv"
+        href="https://github.com/codecheckers/register/blob/master/docs/venues/communities/codecheck_nl/register.csv"
         title="searchable CSV on GitHub">searchable CSV</a> | <a
-        href="https://codecheck.org.uk/register/venues/community/codecheck_nl/register.json"
+        href="https://codecheck.org.uk/register/venues/communities/codecheck_nl/register.json"
         title="JSON export of register">JSON</a> | <a
-        href="https://codecheck.org.uk/register/venues/community/codecheck_nl/register.md"
+        href="https://codecheck.org.uk/register/venues/communities/codecheck_nl/register.md"
         title="Markdown rendering of register">Markdown</a>
 </p>
 

--- a/docs/venues/communities/codecheck_nl/index_postfix.html
+++ b/docs/venues/communities/codecheck_nl/index_postfix.html
@@ -1,11 +1,11 @@
 <p style="margin-bottom: 2em;">
-    <a href="https://raw.githubusercontent.com/codecheckers/register/master/docs/venues/community/codecheck_nl/register.csv"
+    <a href="https://raw.githubusercontent.com/codecheckers/register/master/docs/venues/communities/codecheck_nl/register.csv"
         title="raw CSV of register">CSV source</a> | <a
-        href="https://github.com/codecheckers/register/blob/master/docs/venues/community/codecheck_nl/register.csv"
+        href="https://github.com/codecheckers/register/blob/master/docs/venues/communities/codecheck_nl/register.csv"
         title="searchable CSV on GitHub">searchable CSV</a> | <a
-        href="https://codecheck.org.uk/register/venues/community/codecheck_nl/register.json"
+        href="https://codecheck.org.uk/register/venues/communities/codecheck_nl/register.json"
         title="JSON export of register">JSON</a> | <a
-        href="https://codecheck.org.uk/register/venues/community/codecheck_nl/register.md"
+        href="https://codecheck.org.uk/register/venues/communities/codecheck_nl/register.md"
         title="Markdown rendering of register">Markdown</a>
 </p>
 

--- a/docs/venues/communities/codecheck_nl/stats.json
+++ b/docs/venues/communities/codecheck_nl/stats.json
@@ -1,4 +1,4 @@
 {
-  "source": "https://codecheck.org.uk/register/venues/community/codecheck_nl/register.json",
+  "source": "https://codecheck.org.uk/register/venues/communities/codecheck_nl/register.json",
   "cert_count": 2
 }

--- a/docs/venues/communities/in_press/index.html
+++ b/docs/venues/communities/in_press/index.html
@@ -206,13 +206,13 @@ class="uri">https://doi.org/10.5281/zenodo.3893138</a></td>
 </table>
 
 <p style="margin-bottom: 2em;">
-    <a href="https://raw.githubusercontent.com/codecheckers/register/master/docs/venues/community/in_press/register.csv"
+    <a href="https://raw.githubusercontent.com/codecheckers/register/master/docs/venues/communities/in_press/register.csv"
         title="raw CSV of register">CSV source</a> | <a
-        href="https://github.com/codecheckers/register/blob/master/docs/venues/community/in_press/register.csv"
+        href="https://github.com/codecheckers/register/blob/master/docs/venues/communities/in_press/register.csv"
         title="searchable CSV on GitHub">searchable CSV</a> | <a
-        href="https://codecheck.org.uk/register/venues/community/in_press/register.json"
+        href="https://codecheck.org.uk/register/venues/communities/in_press/register.json"
         title="JSON export of register">JSON</a> | <a
-        href="https://codecheck.org.uk/register/venues/community/in_press/register.md"
+        href="https://codecheck.org.uk/register/venues/communities/in_press/register.md"
         title="Markdown rendering of register">Markdown</a>
 </p>
 

--- a/docs/venues/communities/in_press/index_postfix.html
+++ b/docs/venues/communities/in_press/index_postfix.html
@@ -1,11 +1,11 @@
 <p style="margin-bottom: 2em;">
-    <a href="https://raw.githubusercontent.com/codecheckers/register/master/docs/venues/community/in_press/register.csv"
+    <a href="https://raw.githubusercontent.com/codecheckers/register/master/docs/venues/communities/in_press/register.csv"
         title="raw CSV of register">CSV source</a> | <a
-        href="https://github.com/codecheckers/register/blob/master/docs/venues/community/in_press/register.csv"
+        href="https://github.com/codecheckers/register/blob/master/docs/venues/communities/in_press/register.csv"
         title="searchable CSV on GitHub">searchable CSV</a> | <a
-        href="https://codecheck.org.uk/register/venues/community/in_press/register.json"
+        href="https://codecheck.org.uk/register/venues/communities/in_press/register.json"
         title="JSON export of register">JSON</a> | <a
-        href="https://codecheck.org.uk/register/venues/community/in_press/register.md"
+        href="https://codecheck.org.uk/register/venues/communities/in_press/register.md"
         title="Markdown rendering of register">Markdown</a>
 </p>
 

--- a/docs/venues/communities/in_press/stats.json
+++ b/docs/venues/communities/in_press/stats.json
@@ -1,4 +1,4 @@
 {
-  "source": "https://codecheck.org.uk/register/venues/community/in_press/register.json",
+  "source": "https://codecheck.org.uk/register/venues/communities/in_press/register.json",
   "cert_count": 1
 }

--- a/docs/venues/communities/preprint/index.html
+++ b/docs/venues/communities/preprint/index.html
@@ -299,13 +299,13 @@ class="uri">https://doi.org/10.5281/zenodo.10823246</a></td>
 </table>
 
 <p style="margin-bottom: 2em;">
-    <a href="https://raw.githubusercontent.com/codecheckers/register/master/docs/venues/community/preprint/register.csv"
+    <a href="https://raw.githubusercontent.com/codecheckers/register/master/docs/venues/communities/preprint/register.csv"
         title="raw CSV of register">CSV source</a> | <a
-        href="https://github.com/codecheckers/register/blob/master/docs/venues/community/preprint/register.csv"
+        href="https://github.com/codecheckers/register/blob/master/docs/venues/communities/preprint/register.csv"
         title="searchable CSV on GitHub">searchable CSV</a> | <a
-        href="https://codecheck.org.uk/register/venues/community/preprint/register.json"
+        href="https://codecheck.org.uk/register/venues/communities/preprint/register.json"
         title="JSON export of register">JSON</a> | <a
-        href="https://codecheck.org.uk/register/venues/community/preprint/register.md"
+        href="https://codecheck.org.uk/register/venues/communities/preprint/register.md"
         title="Markdown rendering of register">Markdown</a>
 </p>
 

--- a/docs/venues/communities/preprint/index_postfix.html
+++ b/docs/venues/communities/preprint/index_postfix.html
@@ -1,11 +1,11 @@
 <p style="margin-bottom: 2em;">
-    <a href="https://raw.githubusercontent.com/codecheckers/register/master/docs/venues/community/preprint/register.csv"
+    <a href="https://raw.githubusercontent.com/codecheckers/register/master/docs/venues/communities/preprint/register.csv"
         title="raw CSV of register">CSV source</a> | <a
-        href="https://github.com/codecheckers/register/blob/master/docs/venues/community/preprint/register.csv"
+        href="https://github.com/codecheckers/register/blob/master/docs/venues/communities/preprint/register.csv"
         title="searchable CSV on GitHub">searchable CSV</a> | <a
-        href="https://codecheck.org.uk/register/venues/community/preprint/register.json"
+        href="https://codecheck.org.uk/register/venues/communities/preprint/register.json"
         title="JSON export of register">JSON</a> | <a
-        href="https://codecheck.org.uk/register/venues/community/preprint/register.md"
+        href="https://codecheck.org.uk/register/venues/communities/preprint/register.md"
         title="Markdown rendering of register">Markdown</a>
 </p>
 

--- a/docs/venues/communities/preprint/stats.json
+++ b/docs/venues/communities/preprint/stats.json
@@ -1,4 +1,4 @@
 {
-  "source": "https://codecheck.org.uk/register/venues/community/preprint/register.json",
+  "source": "https://codecheck.org.uk/register/venues/communities/preprint/register.json",
   "cert_count": 9
 }

--- a/docs/venues/conferences/agilegis/index.html
+++ b/docs/venues/conferences/agilegis/index.html
@@ -668,13 +668,13 @@ class="uri">https://doi.org/10.17605/osf.io/8t3bh</a></td>
 </table>
 
 <p style="margin-bottom: 2em;">
-    <a href="https://raw.githubusercontent.com/codecheckers/register/master/docs/venues/conference/agilegis/register.csv"
+    <a href="https://raw.githubusercontent.com/codecheckers/register/master/docs/venues/conferences/agilegis/register.csv"
         title="raw CSV of register">CSV source</a> | <a
-        href="https://github.com/codecheckers/register/blob/master/docs/venues/conference/agilegis/register.csv"
+        href="https://github.com/codecheckers/register/blob/master/docs/venues/conferences/agilegis/register.csv"
         title="searchable CSV on GitHub">searchable CSV</a> | <a
-        href="https://codecheck.org.uk/register/venues/conference/agilegis/register.json"
+        href="https://codecheck.org.uk/register/venues/conferences/agilegis/register.json"
         title="JSON export of register">JSON</a> | <a
-        href="https://codecheck.org.uk/register/venues/conference/agilegis/register.md"
+        href="https://codecheck.org.uk/register/venues/conferences/agilegis/register.md"
         title="Markdown rendering of register">Markdown</a>
 </p>
 

--- a/docs/venues/conferences/agilegis/index_postfix.html
+++ b/docs/venues/conferences/agilegis/index_postfix.html
@@ -1,11 +1,11 @@
 <p style="margin-bottom: 2em;">
-    <a href="https://raw.githubusercontent.com/codecheckers/register/master/docs/venues/conference/agilegis/register.csv"
+    <a href="https://raw.githubusercontent.com/codecheckers/register/master/docs/venues/conferences/agilegis/register.csv"
         title="raw CSV of register">CSV source</a> | <a
-        href="https://github.com/codecheckers/register/blob/master/docs/venues/conference/agilegis/register.csv"
+        href="https://github.com/codecheckers/register/blob/master/docs/venues/conferences/agilegis/register.csv"
         title="searchable CSV on GitHub">searchable CSV</a> | <a
-        href="https://codecheck.org.uk/register/venues/conference/agilegis/register.json"
+        href="https://codecheck.org.uk/register/venues/conferences/agilegis/register.json"
         title="JSON export of register">JSON</a> | <a
-        href="https://codecheck.org.uk/register/venues/conference/agilegis/register.md"
+        href="https://codecheck.org.uk/register/venues/conferences/agilegis/register.md"
         title="Markdown rendering of register">Markdown</a>
 </p>
 

--- a/docs/venues/conferences/agilegis/stats.json
+++ b/docs/venues/conferences/agilegis/stats.json
@@ -1,4 +1,4 @@
 {
-  "source": "https://codecheck.org.uk/register/venues/conference/agilegis/register.json",
+  "source": "https://codecheck.org.uk/register/venues/conferences/agilegis/register.json",
   "cert_count": 41
 }

--- a/docs/venues/journals/gigabyte/index.html
+++ b/docs/venues/journals/gigabyte/index.html
@@ -207,13 +207,13 @@ class="uri">https://doi.org/10.5281/zenodo.7084333</a></td>
 </table>
 
 <p style="margin-bottom: 2em;">
-    <a href="https://raw.githubusercontent.com/codecheckers/register/master/docs/venues/journal/gigabyte/register.csv"
+    <a href="https://raw.githubusercontent.com/codecheckers/register/master/docs/venues/journals/gigabyte/register.csv"
         title="raw CSV of register">CSV source</a> | <a
-        href="https://github.com/codecheckers/register/blob/master/docs/venues/journal/gigabyte/register.csv"
+        href="https://github.com/codecheckers/register/blob/master/docs/venues/journals/gigabyte/register.csv"
         title="searchable CSV on GitHub">searchable CSV</a> | <a
-        href="https://codecheck.org.uk/register/venues/journal/gigabyte/register.json"
+        href="https://codecheck.org.uk/register/venues/journals/gigabyte/register.json"
         title="JSON export of register">JSON</a> | <a
-        href="https://codecheck.org.uk/register/venues/journal/gigabyte/register.md"
+        href="https://codecheck.org.uk/register/venues/journals/gigabyte/register.md"
         title="Markdown rendering of register">Markdown</a>
 </p>
 

--- a/docs/venues/journals/gigabyte/index_postfix.html
+++ b/docs/venues/journals/gigabyte/index_postfix.html
@@ -1,11 +1,11 @@
 <p style="margin-bottom: 2em;">
-    <a href="https://raw.githubusercontent.com/codecheckers/register/master/docs/venues/journal/gigabyte/register.csv"
+    <a href="https://raw.githubusercontent.com/codecheckers/register/master/docs/venues/journals/gigabyte/register.csv"
         title="raw CSV of register">CSV source</a> | <a
-        href="https://github.com/codecheckers/register/blob/master/docs/venues/journal/gigabyte/register.csv"
+        href="https://github.com/codecheckers/register/blob/master/docs/venues/journals/gigabyte/register.csv"
         title="searchable CSV on GitHub">searchable CSV</a> | <a
-        href="https://codecheck.org.uk/register/venues/journal/gigabyte/register.json"
+        href="https://codecheck.org.uk/register/venues/journals/gigabyte/register.json"
         title="JSON export of register">JSON</a> | <a
-        href="https://codecheck.org.uk/register/venues/journal/gigabyte/register.md"
+        href="https://codecheck.org.uk/register/venues/journals/gigabyte/register.md"
         title="Markdown rendering of register">Markdown</a>
 </p>
 

--- a/docs/venues/journals/gigabyte/stats.json
+++ b/docs/venues/journals/gigabyte/stats.json
@@ -1,4 +1,4 @@
 {
-  "source": "https://codecheck.org.uk/register/venues/journal/gigabyte/register.json",
+  "source": "https://codecheck.org.uk/register/venues/journals/gigabyte/register.json",
   "cert_count": 1
 }

--- a/docs/venues/journals/gigascience/index.html
+++ b/docs/venues/journals/gigascience/index.html
@@ -217,13 +217,13 @@ class="uri">https://doi.org/10.5281/zenodo.4964880</a></td>
 </table>
 
 <p style="margin-bottom: 2em;">
-    <a href="https://raw.githubusercontent.com/codecheckers/register/master/docs/venues/journal/gigascience/register.csv"
+    <a href="https://raw.githubusercontent.com/codecheckers/register/master/docs/venues/journals/gigascience/register.csv"
         title="raw CSV of register">CSV source</a> | <a
-        href="https://github.com/codecheckers/register/blob/master/docs/venues/journal/gigascience/register.csv"
+        href="https://github.com/codecheckers/register/blob/master/docs/venues/journals/gigascience/register.csv"
         title="searchable CSV on GitHub">searchable CSV</a> | <a
-        href="https://codecheck.org.uk/register/venues/journal/gigascience/register.json"
+        href="https://codecheck.org.uk/register/venues/journals/gigascience/register.json"
         title="JSON export of register">JSON</a> | <a
-        href="https://codecheck.org.uk/register/venues/journal/gigascience/register.md"
+        href="https://codecheck.org.uk/register/venues/journals/gigascience/register.md"
         title="Markdown rendering of register">Markdown</a>
 </p>
 

--- a/docs/venues/journals/gigascience/index_postfix.html
+++ b/docs/venues/journals/gigascience/index_postfix.html
@@ -1,11 +1,11 @@
 <p style="margin-bottom: 2em;">
-    <a href="https://raw.githubusercontent.com/codecheckers/register/master/docs/venues/journal/gigascience/register.csv"
+    <a href="https://raw.githubusercontent.com/codecheckers/register/master/docs/venues/journals/gigascience/register.csv"
         title="raw CSV of register">CSV source</a> | <a
-        href="https://github.com/codecheckers/register/blob/master/docs/venues/journal/gigascience/register.csv"
+        href="https://github.com/codecheckers/register/blob/master/docs/venues/journals/gigascience/register.csv"
         title="searchable CSV on GitHub">searchable CSV</a> | <a
-        href="https://codecheck.org.uk/register/venues/journal/gigascience/register.json"
+        href="https://codecheck.org.uk/register/venues/journals/gigascience/register.json"
         title="JSON export of register">JSON</a> | <a
-        href="https://codecheck.org.uk/register/venues/journal/gigascience/register.md"
+        href="https://codecheck.org.uk/register/venues/journals/gigascience/register.md"
         title="Markdown rendering of register">Markdown</a>
 </p>
 

--- a/docs/venues/journals/gigascience/stats.json
+++ b/docs/venues/journals/gigascience/stats.json
@@ -1,4 +1,4 @@
 {
-  "source": "https://codecheck.org.uk/register/venues/journal/gigascience/register.json",
+  "source": "https://codecheck.org.uk/register/venues/journals/gigascience/register.json",
   "cert_count": 2
 }

--- a/docs/venues/journals/j_archaeol_sci/index.html
+++ b/docs/venues/journals/j_archaeol_sci/index.html
@@ -206,13 +206,13 @@ class="uri">https://doi.org/10.5281/zenodo.4279275</a></td>
 </table>
 
 <p style="margin-bottom: 2em;">
-    <a href="https://raw.githubusercontent.com/codecheckers/register/master/docs/venues/journal/j_archaeol_sci/register.csv"
+    <a href="https://raw.githubusercontent.com/codecheckers/register/master/docs/venues/journals/j_archaeol_sci/register.csv"
         title="raw CSV of register">CSV source</a> | <a
-        href="https://github.com/codecheckers/register/blob/master/docs/venues/journal/j_archaeol_sci/register.csv"
+        href="https://github.com/codecheckers/register/blob/master/docs/venues/journals/j_archaeol_sci/register.csv"
         title="searchable CSV on GitHub">searchable CSV</a> | <a
-        href="https://codecheck.org.uk/register/venues/journal/j_archaeol_sci/register.json"
+        href="https://codecheck.org.uk/register/venues/journals/j_archaeol_sci/register.json"
         title="JSON export of register">JSON</a> | <a
-        href="https://codecheck.org.uk/register/venues/journal/j_archaeol_sci/register.md"
+        href="https://codecheck.org.uk/register/venues/journals/j_archaeol_sci/register.md"
         title="Markdown rendering of register">Markdown</a>
 </p>
 

--- a/docs/venues/journals/j_archaeol_sci/index_postfix.html
+++ b/docs/venues/journals/j_archaeol_sci/index_postfix.html
@@ -1,11 +1,11 @@
 <p style="margin-bottom: 2em;">
-    <a href="https://raw.githubusercontent.com/codecheckers/register/master/docs/venues/journal/j_archaeol_sci/register.csv"
+    <a href="https://raw.githubusercontent.com/codecheckers/register/master/docs/venues/journals/j_archaeol_sci/register.csv"
         title="raw CSV of register">CSV source</a> | <a
-        href="https://github.com/codecheckers/register/blob/master/docs/venues/journal/j_archaeol_sci/register.csv"
+        href="https://github.com/codecheckers/register/blob/master/docs/venues/journals/j_archaeol_sci/register.csv"
         title="searchable CSV on GitHub">searchable CSV</a> | <a
-        href="https://codecheck.org.uk/register/venues/journal/j_archaeol_sci/register.json"
+        href="https://codecheck.org.uk/register/venues/journals/j_archaeol_sci/register.json"
         title="JSON export of register">JSON</a> | <a
-        href="https://codecheck.org.uk/register/venues/journal/j_archaeol_sci/register.md"
+        href="https://codecheck.org.uk/register/venues/journals/j_archaeol_sci/register.md"
         title="Markdown rendering of register">Markdown</a>
 </p>
 

--- a/docs/venues/journals/j_archaeol_sci/stats.json
+++ b/docs/venues/journals/j_archaeol_sci/stats.json
@@ -1,4 +1,4 @@
 {
-  "source": "https://codecheck.org.uk/register/venues/journal/j_archaeol_sci/register.json",
+  "source": "https://codecheck.org.uk/register/venues/journals/j_archaeol_sci/register.json",
   "cert_count": 1
 }

--- a/docs/venues/journals/j_geogr_syst/index.html
+++ b/docs/venues/journals/j_geogr_syst/index.html
@@ -217,13 +217,13 @@ class="uri">https://doi.org/10.5281/zenodo.4003848</a></td>
 </table>
 
 <p style="margin-bottom: 2em;">
-    <a href="https://raw.githubusercontent.com/codecheckers/register/master/docs/venues/journal/j_geogr_syst/register.csv"
+    <a href="https://raw.githubusercontent.com/codecheckers/register/master/docs/venues/journals/j_geogr_syst/register.csv"
         title="raw CSV of register">CSV source</a> | <a
-        href="https://github.com/codecheckers/register/blob/master/docs/venues/journal/j_geogr_syst/register.csv"
+        href="https://github.com/codecheckers/register/blob/master/docs/venues/journals/j_geogr_syst/register.csv"
         title="searchable CSV on GitHub">searchable CSV</a> | <a
-        href="https://codecheck.org.uk/register/venues/journal/j_geogr_syst/register.json"
+        href="https://codecheck.org.uk/register/venues/journals/j_geogr_syst/register.json"
         title="JSON export of register">JSON</a> | <a
-        href="https://codecheck.org.uk/register/venues/journal/j_geogr_syst/register.md"
+        href="https://codecheck.org.uk/register/venues/journals/j_geogr_syst/register.md"
         title="Markdown rendering of register">Markdown</a>
 </p>
 

--- a/docs/venues/journals/j_geogr_syst/index_postfix.html
+++ b/docs/venues/journals/j_geogr_syst/index_postfix.html
@@ -1,11 +1,11 @@
 <p style="margin-bottom: 2em;">
-    <a href="https://raw.githubusercontent.com/codecheckers/register/master/docs/venues/journal/j_geogr_syst/register.csv"
+    <a href="https://raw.githubusercontent.com/codecheckers/register/master/docs/venues/journals/j_geogr_syst/register.csv"
         title="raw CSV of register">CSV source</a> | <a
-        href="https://github.com/codecheckers/register/blob/master/docs/venues/journal/j_geogr_syst/register.csv"
+        href="https://github.com/codecheckers/register/blob/master/docs/venues/journals/j_geogr_syst/register.csv"
         title="searchable CSV on GitHub">searchable CSV</a> | <a
-        href="https://codecheck.org.uk/register/venues/journal/j_geogr_syst/register.json"
+        href="https://codecheck.org.uk/register/venues/journals/j_geogr_syst/register.json"
         title="JSON export of register">JSON</a> | <a
-        href="https://codecheck.org.uk/register/venues/journal/j_geogr_syst/register.md"
+        href="https://codecheck.org.uk/register/venues/journals/j_geogr_syst/register.md"
         title="Markdown rendering of register">Markdown</a>
 </p>
 

--- a/docs/venues/journals/j_geogr_syst/stats.json
+++ b/docs/venues/journals/j_geogr_syst/stats.json
@@ -1,4 +1,4 @@
 {
-  "source": "https://codecheck.org.uk/register/venues/journal/j_geogr_syst/register.json",
+  "source": "https://codecheck.org.uk/register/venues/journals/j_geogr_syst/register.json",
   "cert_count": 2
 }


### PR DESCRIPTION
Related codecheck repo PR: https://github.com/codecheckers/codecheck/pull/72

Fixed a bug in the individual venue pages- the hyperlinks in the postfix still contained singular form of the venue types which should have been fixed in this PR https://github.com/codecheckers/register/pull/112. 

For instance an example of the fualty hyperlink is:
`https://github.com/codecheckers/register/blob/master/docs/venues/community/codecheck/register.csv`
when it should be
`https://github.com/codecheckers/register/blob/master/docs/venues/communities/codecheck/register.csv`