### PR TITLE
Fix venue type page hyperlinks

### DIFF
--- a/docs/venues/communities/index.html
+++ b/docs/venues/communities/index.html
@@ -229,7 +229,7 @@ all checks)</a></td>
 
 <p style="margin-bottom: 2em;">
     <a
-        href="https://codecheck.org.uk/register/venues/community/index.json"
+        href="https://codecheck.org.uk/register/venues/communities/index.json"
         title="JSON export of list">JSON</a>
 </p>
 

--- a/docs/venues/communities/index_postfix.html
+++ b/docs/venues/communities/index_postfix.html
@@ -1,6 +1,6 @@
 <p style="margin-bottom: 2em;">
     <a
-        href="https://codecheck.org.uk/register/venues/community/index.json"
+        href="https://codecheck.org.uk/register/venues/communities/index.json"
         title="JSON export of list">JSON</a>
 </p>
 

--- a/docs/venues/conferences/index.html
+++ b/docs/venues/conferences/index.html
@@ -199,7 +199,7 @@ all checks)</a></td>
 
 <p style="margin-bottom: 2em;">
     <a
-        href="https://codecheck.org.uk/register/venues/conference/index.json"
+        href="https://codecheck.org.uk/register/venues/conferences/index.json"
         title="JSON export of list">JSON</a>
 </p>
 

--- a/docs/venues/conferences/index_postfix.html
+++ b/docs/venues/conferences/index_postfix.html
@@ -1,6 +1,6 @@
 <p style="margin-bottom: 2em;">
     <a
-        href="https://codecheck.org.uk/register/venues/conference/index.json"
+        href="https://codecheck.org.uk/register/venues/conferences/index.json"
         title="JSON export of list">JSON</a>
 </p>
 

--- a/docs/venues/journals/index.html
+++ b/docs/venues/journals/index.html
@@ -221,7 +221,7 @@ all checks)</a></td>
 
 <p style="margin-bottom: 2em;">
     <a
-        href="https://codecheck.org.uk/register/venues/journal/index.json"
+        href="https://codecheck.org.uk/register/venues/journals/index.json"
         title="JSON export of list">JSON</a>
 </p>
 

--- a/docs/venues/journals/index_postfix.html
+++ b/docs/venues/journals/index_postfix.html
@@ -1,6 +1,6 @@
 <p style="margin-bottom: 2em;">
     <a
-        href="https://codecheck.org.uk/register/venues/journal/index.json"
+        href="https://codecheck.org.uk/register/venues/journals/index.json"
         title="JSON export of list">JSON</a>
 </p>
 


### PR DESCRIPTION
Related codecheck repo PR: https://github.com/codecheckers/codecheck/pull/73

Fixed a bug in the venue type pages- the hyperlinks in the postfix still contained singular form of the venue types which should have been fixed in this PR https://github.com/codecheckers/register/pull/112. 

For instance an example of the fualty hyperlink is:
`https://codecheck.org.uk/register/venues/community/index.json`
when it should be
`https://codecheck.org.uk/register/venues/communities/index.json`