### PR TITLE
Add reproducibility reviews from AGILE 2024 - closes #69

### DIFF
--- a/register.csv
+++ b/register.csv
@@ -67,3 +67,11 @@ Certificate,Repository,Type,Venue,Issue
 2024-002,github::codecheckers/domestic.wastewater.variability,community,codecheck NL,61
 2024-003,github::codecheckers/sddtmpc,community,codecheck NL,66
 2024-004,github::langtonhugh/scope,community,AUMC,96
+2024-006,osf::ymc3t,conference,AGILEGIS,69
+2024-007,osf::gvpd9,conference,AGILEGIS,69
+2024-008,osf::3nbjw,conference,AGILEGIS,69
+2024-009,osf::csb7r,conference,AGILEGIS,69
+2024-010,osf::nbk57,conference,AGILEGIS,69
+2024-011,osf::fmgb4,conference,AGILEGIS,69
+2024-012,osf::w42ad,conference,AGILEGIS,69
+2024-013,osf::txgzv,conference,AGILEGIS,69


### PR DESCRIPTION
Two CODECHECK config files are still missing in these two repos:

- https://osf.io/fmgb4/
- https://osf.io/nbk57/

I'm sure I'll quickly sort this out with the help of @remydecoupes