### PR TITLE
Fix codechecker hyperlink when no orcid id is there 

### DIFF
--- a/docs/certs/2024-003/index.html
+++ b/docs/certs/2024-003/index.html
@@ -286,8 +286,8 @@ Codecheck details
 </p>
 <p>
 <strong>Codechecker names</strong>: <a
-href="https://orcid.org/0000-0001-8607-8025">Stephen J. Eglen</a>, <a
-href="https://orcid.org/">Delft 2024-05 participants</a>
+href="https://orcid.org/0000-0001-8607-8025">Stephen J. Eglen</a>, Delft
+2024-05 participants
 </p>
 <p>
 <strong>Time of codecheck</strong>: 2024-05-30 11:30:00

--- a/docs/certs/2024-006/index.html
+++ b/docs/certs/2024-006/index.html
@@ -289,9 +289,8 @@ Codecheck details
 <strong>Certificate identifier</strong>: 2024-006
 </p>
 <p>
-<strong>Codechecker names</strong>: <a href="https://orcid.org/">Adhitya
-Bhawiyuga</a>, <a href="https://orcid.org/">Nadia Shafaeipour</a>, <a
-href="https://orcid.org/">Nestor de la Paz Ruiz</a>, <a
+<strong>Codechecker names</strong>: Adhitya Bhawiyuga, Nadia
+Shafaeipour, Nestor de la Paz Ruiz, <a
 href="https://orcid.org/0000-0002-0504-9677">Patrick Eneche</a>, <a
 href="https://orcid.org/0000-0002-9317-8291">Frank Ostermann</a>
 </p>

--- a/docs/certs/2024-007/index.html
+++ b/docs/certs/2024-007/index.html
@@ -287,11 +287,8 @@ Codecheck details
 <strong>Certificate identifier</strong>: 2024-007
 </p>
 <p>
-<strong>Codechecker names</strong>: <a
-href="https://orcid.org/">Betelham Gebretsadik</a>, <a
-href="https://orcid.org/">Dilli Paudel</a>, <a
-href="https://orcid.org/">Jay Gohil</a>, <a
-href="https://orcid.org/">Pitchaporn Likitpanjamanon</a>
+<strong>Codechecker names</strong>: Betelham Gebretsadik, Dilli Paudel,
+Jay Gohil, Pitchaporn Likitpanjamanon
 </p>
 <p>
 <strong>Time of codecheck</strong>: 2024-09-26


### PR DESCRIPTION
In the cert pages- codechecker names with no associated orcid IDs should not have a hyperlink but it does.
This issue is fixed in the codecheck PR [link](https://github.com/codecheckers/codecheck/pull/77)

The files were rerendered here
