### PR TITLE
Fix "NA" values in no.codechecks column in "List of codecheckers" page

### DIFF
--- a/docs/codecheckers/index.html
+++ b/docs/codecheckers/index.html
@@ -55,7 +55,8 @@
   div.column{display: inline-block; vertical-align: top; width: 50%;}
   div.hanging-indent{margin-left: 1.5em; text-indent: -1.5em;}
   ul.task-list{list-style: none;}
-    </style>
+      .display.math{display: block; text-align: center; margin: 0.5rem auto;}
+  </style>
 
 
 
@@ -167,12 +168,18 @@ pre code {
 
 
 <h1 class="title toc-ignore">CODECHECK List of codecheckers</h1>
-<h3 class="subtitle">In total, 42 codecheckers contributed 89 codechecks</h3>
+<h3 class="subtitle">In total, 42 codecheckers contributed 89
+codechecks</h3>
 
 </div>
 
 
 <table>
+<colgroup>
+<col width="26%" />
+<col width="48%" />
+<col width="24%" />
+</colgroup>
 <thead>
 <tr class="header">
 <th align="left">Codechecker name</th>
@@ -182,218 +189,428 @@ pre code {
 </thead>
 <tbody>
 <tr class="odd">
-<td align="left"><a href="https://codecheck.org.uk/register/codecheckers/0000-0001-8607-8025/">Stephen J. Eglen</a></td>
-<td align="left"><a href="https://orcid.org/0000-0001-8607-8025">0000-0001-8607-8025</a></td>
-<td align="left">NA <a href="https://codecheck.org.uk/register/codecheckers/0000-0001-8607-8025/">(see all checks)</a></td>
+<td align="left"><a
+href="https://codecheck.org.uk/register/codecheckers/0000-0001-8607-8025/">Stephen
+J. Eglen</a></td>
+<td align="left"><a
+href="https://orcid.org/0000-0001-8607-8025">0000-0001-8607-8025</a></td>
+<td align="left">16 <a
+href="https://codecheck.org.uk/register/codecheckers/0000-0001-8607-8025/">(see
+all checks)</a></td>
 </tr>
 <tr class="even">
-<td align="left"><a href="https://codecheck.org.uk/register/codecheckers/0000-0002-0024-5046/">Daniel Nüst</a></td>
-<td align="left"><a href="https://orcid.org/0000-0002-0024-5046">0000-0002-0024-5046</a></td>
-<td align="left">NA <a href="https://codecheck.org.uk/register/codecheckers/0000-0002-0024-5046/">(see all checks)</a></td>
+<td align="left"><a
+href="https://codecheck.org.uk/register/codecheckers/0000-0002-0024-5046/">Daniel
+Nüst</a></td>
+<td align="left"><a
+href="https://orcid.org/0000-0002-0024-5046">0000-0002-0024-5046</a></td>
+<td align="left">20 <a
+href="https://codecheck.org.uk/register/codecheckers/0000-0002-0024-5046/">(see
+all checks)</a></td>
 </tr>
 <tr class="odd">
-<td align="left"><a href="https://codecheck.org.uk/register/codecheckers/0000-0002-5361-6285/">Iain Davies</a></td>
-<td align="left"><a href="https://orcid.org/0000-0002-5361-6285">0000-0002-5361-6285</a></td>
-<td align="left">NA <a href="https://codecheck.org.uk/register/codecheckers/0000-0002-5361-6285/">(see all checks)</a></td>
+<td align="left"><a
+href="https://codecheck.org.uk/register/codecheckers/0000-0002-5361-6285/">Iain
+Davies</a></td>
+<td align="left"><a
+href="https://orcid.org/0000-0002-5361-6285">0000-0002-5361-6285</a></td>
+<td align="left">5 <a
+href="https://codecheck.org.uk/register/codecheckers/0000-0002-5361-6285/">(see
+all checks)</a></td>
 </tr>
 <tr class="even">
-<td align="left"><a href="https://codecheck.org.uk/register/codecheckers/0000-0003-1004-9695/">Carlos Granell</a></td>
-<td align="left"><a href="https://orcid.org/0000-0003-1004-9695">0000-0003-1004-9695</a></td>
-<td align="left">NA <a href="https://codecheck.org.uk/register/codecheckers/0000-0003-1004-9695/">(see all checks)</a></td>
+<td align="left"><a
+href="https://codecheck.org.uk/register/codecheckers/0000-0003-1004-9695/">Carlos
+Granell</a></td>
+<td align="left"><a
+href="https://orcid.org/0000-0003-1004-9695">0000-0003-1004-9695</a></td>
+<td align="left">5 <a
+href="https://codecheck.org.uk/register/codecheckers/0000-0003-1004-9695/">(see
+all checks)</a></td>
 </tr>
 <tr class="odd">
-<td align="left"><a href="https://codecheck.org.uk/register/codecheckers/0000-0002-9317-8291/">Frank Ostermann</a></td>
-<td align="left"><a href="https://orcid.org/0000-0002-9317-8291">0000-0002-9317-8291</a></td>
-<td align="left">NA <a href="https://codecheck.org.uk/register/codecheckers/0000-0002-9317-8291/">(see all checks)</a></td>
+<td align="left"><a
+href="https://codecheck.org.uk/register/codecheckers/0000-0002-9317-8291/">Frank
+Ostermann</a></td>
+<td align="left"><a
+href="https://orcid.org/0000-0002-9317-8291">0000-0002-9317-8291</a></td>
+<td align="left">9 <a
+href="https://codecheck.org.uk/register/codecheckers/0000-0002-9317-8291/">(see
+all checks)</a></td>
 </tr>
 <tr class="even">
-<td align="left"><a href="https://codecheck.org.uk/register/codecheckers/0000-0002-2648-4790/">Marcel Stimberg</a></td>
-<td align="left"><a href="https://orcid.org/0000-0002-2648-4790">0000-0002-2648-4790</a></td>
-<td align="left">NA <a href="https://codecheck.org.uk/register/codecheckers/0000-0002-2648-4790/">(see all checks)</a></td>
+<td align="left"><a
+href="https://codecheck.org.uk/register/codecheckers/0000-0002-2648-4790/">Marcel
+Stimberg</a></td>
+<td align="left"><a
+href="https://orcid.org/0000-0002-2648-4790">0000-0002-2648-4790</a></td>
+<td align="left">1 <a
+href="https://codecheck.org.uk/register/codecheckers/0000-0002-2648-4790/">(see
+all checks)</a></td>
 </tr>
 <tr class="odd">
-<td align="left"><a href="https://codecheck.org.uk/register/codecheckers/0000-0002-3124-5364/">Philipp A. Friese</a></td>
-<td align="left"><a href="https://orcid.org/0000-0002-3124-5364">0000-0002-3124-5364</a></td>
-<td align="left">NA <a href="https://codecheck.org.uk/register/codecheckers/0000-0002-3124-5364/">(see all checks)</a></td>
+<td align="left"><a
+href="https://codecheck.org.uk/register/codecheckers/0000-0002-3124-5364/">Philipp
+A. Friese</a></td>
+<td align="left"><a
+href="https://orcid.org/0000-0002-3124-5364">0000-0002-3124-5364</a></td>
+<td align="left">7 <a
+href="https://codecheck.org.uk/register/codecheckers/0000-0002-3124-5364/">(see
+all checks)</a></td>
 </tr>
 <tr class="even">
-<td align="left"><a href="https://codecheck.org.uk/register/codecheckers/0000-0001-5361-2885/">Anita Graser</a></td>
-<td align="left"><a href="https://orcid.org/0000-0001-5361-2885">0000-0001-5361-2885</a></td>
-<td align="left">NA <a href="https://codecheck.org.uk/register/codecheckers/0000-0001-5361-2885/">(see all checks)</a></td>
+<td align="left"><a
+href="https://codecheck.org.uk/register/codecheckers/0000-0001-5361-2885/">Anita
+Graser</a></td>
+<td align="left"><a
+href="https://orcid.org/0000-0001-5361-2885">0000-0001-5361-2885</a></td>
+<td align="left">2 <a
+href="https://codecheck.org.uk/register/codecheckers/0000-0001-5361-2885/">(see
+all checks)</a></td>
 </tr>
 <tr class="odd">
-<td align="left"><a href="https://codecheck.org.uk/register/codecheckers/0000-0003-2615-8757/">Jakub Krukar</a></td>
-<td align="left"><a href="https://orcid.org/0000-0003-2615-8757">0000-0003-2615-8757</a></td>
-<td align="left">NA <a href="https://codecheck.org.uk/register/codecheckers/0000-0003-2615-8757/">(see all checks)</a></td>
+<td align="left"><a
+href="https://codecheck.org.uk/register/codecheckers/0000-0003-2615-8757/">Jakub
+Krukar</a></td>
+<td align="left"><a
+href="https://orcid.org/0000-0003-2615-8757">0000-0003-2615-8757</a></td>
+<td align="left">4 <a
+href="https://codecheck.org.uk/register/codecheckers/0000-0003-2615-8757/">(see
+all checks)</a></td>
 </tr>
 <tr class="even">
-<td align="left"><a href="https://codecheck.org.uk/register/codecheckers/0000-0003-4386-4450/">Alexander Kmoch</a></td>
-<td align="left"><a href="https://orcid.org/0000-0003-4386-4450">0000-0003-4386-4450</a></td>
-<td align="left">NA <a href="https://codecheck.org.uk/register/codecheckers/0000-0003-4386-4450/">(see all checks)</a></td>
+<td align="left"><a
+href="https://codecheck.org.uk/register/codecheckers/0000-0003-4386-4450/">Alexander
+Kmoch</a></td>
+<td align="left"><a
+href="https://orcid.org/0000-0003-4386-4450">0000-0003-4386-4450</a></td>
+<td align="left">2 <a
+href="https://codecheck.org.uk/register/codecheckers/0000-0003-4386-4450/">(see
+all checks)</a></td>
 </tr>
 <tr class="odd">
-<td align="left"><a href="https://codecheck.org.uk/register/codecheckers/0000-0003-0863-9581/">Rémy Decoupes</a></td>
-<td align="left"><a href="https://orcid.org/0000-0003-0863-9581">0000-0003-0863-9581</a></td>
-<td align="left">NA <a href="https://codecheck.org.uk/register/codecheckers/0000-0003-0863-9581/">(see all checks)</a></td>
+<td align="left"><a
+href="https://codecheck.org.uk/register/codecheckers/0000-0003-0863-9581/">Rémy
+Decoupes</a></td>
+<td align="left"><a
+href="https://orcid.org/0000-0003-0863-9581">0000-0003-0863-9581</a></td>
+<td align="left">6 <a
+href="https://codecheck.org.uk/register/codecheckers/0000-0003-0863-9581/">(see
+all checks)</a></td>
 </tr>
 <tr class="even">
-<td align="left"><a href="https://codecheck.org.uk/register/codecheckers/0000-0003-1162-7389/">Eleni Tomai</a></td>
-<td align="left"><a href="https://orcid.org/0000-0003-1162-7389">0000-0003-1162-7389</a></td>
-<td align="left">NA <a href="https://codecheck.org.uk/register/codecheckers/0000-0003-1162-7389/">(see all checks)</a></td>
+<td align="left"><a
+href="https://codecheck.org.uk/register/codecheckers/0000-0003-1162-7389/">Eleni
+Tomai</a></td>
+<td align="left"><a
+href="https://orcid.org/0000-0003-1162-7389">0000-0003-1162-7389</a></td>
+<td align="left">2 <a
+href="https://codecheck.org.uk/register/codecheckers/0000-0003-1162-7389/">(see
+all checks)</a></td>
 </tr>
 <tr class="odd">
-<td align="left"><a href="https://codecheck.org.uk/register/codecheckers/0000-0003-0928-1139/">Eftychia Koukouraki</a></td>
-<td align="left"><a href="https://orcid.org/0000-0003-0928-1139">0000-0003-0928-1139</a></td>
-<td align="left">NA <a href="https://codecheck.org.uk/register/codecheckers/0000-0003-0928-1139/">(see all checks)</a></td>
+<td align="left"><a
+href="https://codecheck.org.uk/register/codecheckers/0000-0003-0928-1139/">Eftychia
+Koukouraki</a></td>
+<td align="left"><a
+href="https://orcid.org/0000-0003-0928-1139">0000-0003-0928-1139</a></td>
+<td align="left">5 <a
+href="https://codecheck.org.uk/register/codecheckers/0000-0003-0928-1139/">(see
+all checks)</a></td>
 </tr>
 <tr class="even">
-<td align="left"><a href="https://codecheck.org.uk/register/codecheckers/0000-0002-8381-3749/">Raniere Silva</a></td>
-<td align="left"><a href="https://orcid.org/0000-0002-8381-3749">0000-0002-8381-3749</a></td>
-<td align="left">NA <a href="https://codecheck.org.uk/register/codecheckers/0000-0002-8381-3749/">(see all checks)</a></td>
+<td align="left"><a
+href="https://codecheck.org.uk/register/codecheckers/0000-0002-8381-3749/">Raniere
+Silva</a></td>
+<td align="left"><a
+href="https://orcid.org/0000-0002-8381-3749">0000-0002-8381-3749</a></td>
+<td align="left">1 <a
+href="https://codecheck.org.uk/register/codecheckers/0000-0002-8381-3749/">(see
+all checks)</a></td>
 </tr>
 <tr class="odd">
-<td align="left"><a href="https://codecheck.org.uk/register/codecheckers/0000-0002-8160-7634/">Nina Wiedemann</a></td>
-<td align="left"><a href="https://orcid.org/0000-0002-8160-7634">0000-0002-8160-7634</a></td>
-<td align="left">NA <a href="https://codecheck.org.uk/register/codecheckers/0000-0002-8160-7634/">(see all checks)</a></td>
+<td align="left"><a
+href="https://codecheck.org.uk/register/codecheckers/0000-0002-8160-7634/">Nina
+Wiedemann</a></td>
+<td align="left"><a
+href="https://orcid.org/0000-0002-8160-7634">0000-0002-8160-7634</a></td>
+<td align="left">2 <a
+href="https://codecheck.org.uk/register/codecheckers/0000-0002-8160-7634/">(see
+all checks)</a></td>
 </tr>
 <tr class="even">
-<td align="left"><a href="https://codecheck.org.uk/register/codecheckers/0000-0003-3696-0030/">Mehtab Alam Syed</a></td>
-<td align="left"><a href="https://orcid.org/0000-0003-3696-0030">0000-0003-3696-0030</a></td>
-<td align="left">NA <a href="https://codecheck.org.uk/register/codecheckers/0000-0003-3696-0030/">(see all checks)</a></td>
+<td align="left"><a
+href="https://codecheck.org.uk/register/codecheckers/0000-0003-3696-0030/">Mehtab
+Alam Syed</a></td>
+<td align="left"><a
+href="https://orcid.org/0000-0003-3696-0030">0000-0003-3696-0030</a></td>
+<td align="left">1 <a
+href="https://codecheck.org.uk/register/codecheckers/0000-0003-3696-0030/">(see
+all checks)</a></td>
 </tr>
 <tr class="odd">
-<td align="left"><a href="https://codecheck.org.uk/register/codecheckers/NA/">NA</a></td>
+<td align="left"><a
+href="https://codecheck.org.uk/register/codecheckers/NA/">NA</a></td>
 <td align="left"><a href="https://orcid.org/NA">NA</a></td>
-<td align="left">NA <a href="https://codecheck.org.uk/register/codecheckers/NA/">(see all checks)</a></td>
+<td align="left">12 <a
+href="https://codecheck.org.uk/register/codecheckers/NA/">(see all
+checks)</a></td>
 </tr>
 <tr class="even">
-<td align="left"><a href="https://codecheck.org.uk/register/codecheckers/0000-0002-1322-1553/">Samuel Langton</a></td>
-<td align="left"><a href="https://orcid.org/0000-0002-1322-1553">0000-0002-1322-1553</a></td>
-<td align="left">NA <a href="https://codecheck.org.uk/register/codecheckers/0000-0002-1322-1553/">(see all checks)</a></td>
+<td align="left"><a
+href="https://codecheck.org.uk/register/codecheckers/0000-0002-1322-1553/">Samuel
+Langton</a></td>
+<td align="left"><a
+href="https://orcid.org/0000-0002-1322-1553">0000-0002-1322-1553</a></td>
+<td align="left">2 <a
+href="https://codecheck.org.uk/register/codecheckers/0000-0002-1322-1553/">(see
+all checks)</a></td>
 </tr>
 <tr class="odd">
-<td align="left"><a href="https://codecheck.org.uk/register/codecheckers/0000-0002-6446-1901/">Lukas Röseler</a></td>
-<td align="left"><a href="https://orcid.org/0000-0002-6446-1901">0000-0002-6446-1901</a></td>
-<td align="left">NA <a href="https://codecheck.org.uk/register/codecheckers/0000-0002-6446-1901/">(see all checks)</a></td>
+<td align="left"><a
+href="https://codecheck.org.uk/register/codecheckers/0000-0002-6446-1901/">Lukas
+Röseler</a></td>
+<td align="left"><a
+href="https://orcid.org/0000-0002-6446-1901">0000-0002-6446-1901</a></td>
+<td align="left">1 <a
+href="https://codecheck.org.uk/register/codecheckers/0000-0002-6446-1901/">(see
+all checks)</a></td>
 </tr>
 <tr class="even">
-<td align="left"><a href="https://codecheck.org.uk/register/codecheckers/0000-0002-0504-9677/">Patrick Eneche</a></td>
-<td align="left"><a href="https://orcid.org/0000-0002-0504-9677">0000-0002-0504-9677</a></td>
-<td align="left">NA <a href="https://codecheck.org.uk/register/codecheckers/0000-0002-0504-9677/">(see all checks)</a></td>
+<td align="left"><a
+href="https://codecheck.org.uk/register/codecheckers/0000-0002-0504-9677/">Patrick
+Eneche</a></td>
+<td align="left"><a
+href="https://orcid.org/0000-0002-0504-9677">0000-0002-0504-9677</a></td>
+<td align="left">1 <a
+href="https://codecheck.org.uk/register/codecheckers/0000-0002-0504-9677/">(see
+all checks)</a></td>
 </tr>
 <tr class="odd">
-<td align="left"><a href="https://codecheck.org.uk/register/codecheckers/0009-0002-8188-6271/">Amira Al Balushi</a></td>
-<td align="left"><a href="https://orcid.org/0009-0002-8188-6271">0009-0002-8188-6271</a></td>
-<td align="left">NA <a href="https://codecheck.org.uk/register/codecheckers/0009-0002-8188-6271/">(see all checks)</a></td>
+<td align="left"><a
+href="https://codecheck.org.uk/register/codecheckers/0009-0002-8188-6271/">Amira
+Al Balushi</a></td>
+<td align="left"><a
+href="https://orcid.org/0009-0002-8188-6271">0009-0002-8188-6271</a></td>
+<td align="left">1 <a
+href="https://codecheck.org.uk/register/codecheckers/0009-0002-8188-6271/">(see
+all checks)</a></td>
 </tr>
 <tr class="even">
-<td align="left"><a href="https://codecheck.org.uk/register/codecheckers/0000-0002-6875-1551/">Angelina Momin</a></td>
-<td align="left"><a href="https://orcid.org/0000-0002-6875-1551">0000-0002-6875-1551</a></td>
-<td align="left">NA <a href="https://codecheck.org.uk/register/codecheckers/0000-0002-6875-1551/">(see all checks)</a></td>
+<td align="left"><a
+href="https://codecheck.org.uk/register/codecheckers/0000-0002-6875-1551/">Angelina
+Momin</a></td>
+<td align="left"><a
+href="https://orcid.org/0000-0002-6875-1551">0000-0002-6875-1551</a></td>
+<td align="left">1 <a
+href="https://codecheck.org.uk/register/codecheckers/0000-0002-6875-1551/">(see
+all checks)</a></td>
 </tr>
 <tr class="odd">
-<td align="left"><a href="https://codecheck.org.uk/register/codecheckers/0000-0003-2177-7882/">Jasper van Doninck</a></td>
-<td align="left"><a href="https://orcid.org/0000-0003-2177-7882">0000-0003-2177-7882</a></td>
-<td align="left">NA <a href="https://codecheck.org.uk/register/codecheckers/0000-0003-2177-7882/">(see all checks)</a></td>
+<td align="left"><a
+href="https://codecheck.org.uk/register/codecheckers/0000-0003-2177-7882/">Jasper
+van Doninck</a></td>
+<td align="left"><a
+href="https://orcid.org/0000-0003-2177-7882">0000-0003-2177-7882</a></td>
+<td align="left">1 <a
+href="https://codecheck.org.uk/register/codecheckers/0000-0003-2177-7882/">(see
+all checks)</a></td>
 </tr>
 <tr class="even">
-<td align="left"><a href="https://codecheck.org.uk/register/codecheckers/0009-0008-5638-1670/">Mareike Wendelmuth</a></td>
-<td align="left"><a href="https://orcid.org/0009-0008-5638-1670">0009-0008-5638-1670</a></td>
-<td align="left">NA <a href="https://codecheck.org.uk/register/codecheckers/0009-0008-5638-1670/">(see all checks)</a></td>
+<td align="left"><a
+href="https://codecheck.org.uk/register/codecheckers/0009-0008-5638-1670/">Mareike
+Wendelmuth</a></td>
+<td align="left"><a
+href="https://orcid.org/0009-0008-5638-1670">0009-0008-5638-1670</a></td>
+<td align="left">1 <a
+href="https://codecheck.org.uk/register/codecheckers/0009-0008-5638-1670/">(see
+all checks)</a></td>
 </tr>
 <tr class="odd">
-<td align="left"><a href="https://codecheck.org.uk/register/codecheckers/0009-0005-9240-7370/">Yasel Quintero</a></td>
-<td align="left"><a href="https://orcid.org/0009-0005-9240-7370">0009-0005-9240-7370</a></td>
-<td align="left">NA <a href="https://codecheck.org.uk/register/codecheckers/0009-0005-9240-7370/">(see all checks)</a></td>
+<td align="left"><a
+href="https://codecheck.org.uk/register/codecheckers/0009-0005-9240-7370/">Yasel
+Quintero</a></td>
+<td align="left"><a
+href="https://orcid.org/0009-0005-9240-7370">0009-0005-9240-7370</a></td>
+<td align="left">1 <a
+href="https://codecheck.org.uk/register/codecheckers/0009-0005-9240-7370/">(see
+all checks)</a></td>
 </tr>
 <tr class="even">
-<td align="left"><a href="https://codecheck.org.uk/register/codecheckers/0009-0002-2379-0060/">Joslyn Sun</a></td>
-<td align="left"><a href="https://orcid.org/0009-0002-2379-0060">0009-0002-2379-0060</a></td>
-<td align="left">NA <a href="https://codecheck.org.uk/register/codecheckers/0009-0002-2379-0060/">(see all checks)</a></td>
+<td align="left"><a
+href="https://codecheck.org.uk/register/codecheckers/0009-0002-2379-0060/">Joslyn
+Sun</a></td>
+<td align="left"><a
+href="https://orcid.org/0009-0002-2379-0060">0009-0002-2379-0060</a></td>
+<td align="left">1 <a
+href="https://codecheck.org.uk/register/codecheckers/0009-0002-2379-0060/">(see
+all checks)</a></td>
 </tr>
 <tr class="odd">
-<td align="left"><a href="https://codecheck.org.uk/register/codecheckers/0000-0003-4324-5350/">Roel Janssen</a></td>
-<td align="left"><a href="https://orcid.org/0000-0003-4324-5350">0000-0003-4324-5350</a></td>
-<td align="left">NA <a href="https://codecheck.org.uk/register/codecheckers/0000-0003-4324-5350/">(see all checks)</a></td>
+<td align="left"><a
+href="https://codecheck.org.uk/register/codecheckers/0000-0003-4324-5350/">Roel
+Janssen</a></td>
+<td align="left"><a
+href="https://orcid.org/0000-0003-4324-5350">0000-0003-4324-5350</a></td>
+<td align="left">1 <a
+href="https://codecheck.org.uk/register/codecheckers/0000-0003-4324-5350/">(see
+all checks)</a></td>
 </tr>
 <tr class="even">
-<td align="left"><a href="https://codecheck.org.uk/register/codecheckers/0000-0002-0820-6674/">Joey Tang</a></td>
-<td align="left"><a href="https://orcid.org/0000-0002-0820-6674">0000-0002-0820-6674</a></td>
-<td align="left">NA <a href="https://codecheck.org.uk/register/codecheckers/0000-0002-0820-6674/">(see all checks)</a></td>
+<td align="left"><a
+href="https://codecheck.org.uk/register/codecheckers/0000-0002-0820-6674/">Joey
+Tang</a></td>
+<td align="left"><a
+href="https://orcid.org/0000-0002-0820-6674">0000-0002-0820-6674</a></td>
+<td align="left">1 <a
+href="https://codecheck.org.uk/register/codecheckers/0000-0002-0820-6674/">(see
+all checks)</a></td>
 </tr>
 <tr class="odd">
-<td align="left"><a href="https://codecheck.org.uk/register/codecheckers/0009-0003-8352-7288/">Max Reichert</a></td>
-<td align="left"><a href="https://orcid.org/0009-0003-8352-7288">0009-0003-8352-7288</a></td>
-<td align="left">NA <a href="https://codecheck.org.uk/register/codecheckers/0009-0003-8352-7288/">(see all checks)</a></td>
+<td align="left"><a
+href="https://codecheck.org.uk/register/codecheckers/0009-0003-8352-7288/">Max
+Reichert</a></td>
+<td align="left"><a
+href="https://orcid.org/0009-0003-8352-7288">0009-0003-8352-7288</a></td>
+<td align="left">1 <a
+href="https://codecheck.org.uk/register/codecheckers/0009-0003-8352-7288/">(see
+all checks)</a></td>
 </tr>
 <tr class="even">
-<td align="left"><a href="https://codecheck.org.uk/register/codecheckers/0009-0002-4934-1474/">Flora Zhou</a></td>
-<td align="left"><a href="https://orcid.org/0009-0002-4934-1474">0009-0002-4934-1474</a></td>
-<td align="left">NA <a href="https://codecheck.org.uk/register/codecheckers/0009-0002-4934-1474/">(see all checks)</a></td>
+<td align="left"><a
+href="https://codecheck.org.uk/register/codecheckers/0009-0002-4934-1474/">Flora
+Zhou</a></td>
+<td align="left"><a
+href="https://orcid.org/0009-0002-4934-1474">0009-0002-4934-1474</a></td>
+<td align="left">1 <a
+href="https://codecheck.org.uk/register/codecheckers/0009-0002-4934-1474/">(see
+all checks)</a></td>
 </tr>
 <tr class="odd">
-<td align="left"><a href="https://codecheck.org.uk/register/codecheckers/0000-0002-8936-0365/">Eduard Klapwijk</a></td>
-<td align="left"><a href="https://orcid.org/0000-0002-8936-0365">0000-0002-8936-0365</a></td>
-<td align="left">NA <a href="https://codecheck.org.uk/register/codecheckers/0000-0002-8936-0365/">(see all checks)</a></td>
+<td align="left"><a
+href="https://codecheck.org.uk/register/codecheckers/0000-0002-8936-0365/">Eduard
+Klapwijk</a></td>
+<td align="left"><a
+href="https://orcid.org/0000-0002-8936-0365">0000-0002-8936-0365</a></td>
+<td align="left">1 <a
+href="https://codecheck.org.uk/register/codecheckers/0000-0002-8936-0365/">(see
+all checks)</a></td>
 </tr>
 <tr class="even">
-<td align="left"><a href="https://codecheck.org.uk/register/codecheckers/0009-0008-5383-5497/">Tina Rozsos</a></td>
-<td align="left"><a href="https://orcid.org/0009-0008-5383-5497">0009-0008-5383-5497</a></td>
-<td align="left">NA <a href="https://codecheck.org.uk/register/codecheckers/0009-0008-5383-5497/">(see all checks)</a></td>
+<td align="left"><a
+href="https://codecheck.org.uk/register/codecheckers/0009-0008-5383-5497/">Tina
+Rozsos</a></td>
+<td align="left"><a
+href="https://orcid.org/0009-0008-5383-5497">0009-0008-5383-5497</a></td>
+<td align="left">1 <a
+href="https://codecheck.org.uk/register/codecheckers/0009-0008-5383-5497/">(see
+all checks)</a></td>
 </tr>
 <tr class="odd">
-<td align="left"><a href="https://codecheck.org.uk/register/codecheckers/0009-0004-3684-3584/">Stijn Peeters</a></td>
-<td align="left"><a href="https://orcid.org/0009-0004-3684-3584">0009-0004-3684-3584</a></td>
-<td align="left">NA <a href="https://codecheck.org.uk/register/codecheckers/0009-0004-3684-3584/">(see all checks)</a></td>
+<td align="left"><a
+href="https://codecheck.org.uk/register/codecheckers/0009-0004-3684-3584/">Stijn
+Peeters</a></td>
+<td align="left"><a
+href="https://orcid.org/0009-0004-3684-3584">0009-0004-3684-3584</a></td>
+<td align="left">1 <a
+href="https://codecheck.org.uk/register/codecheckers/0009-0004-3684-3584/">(see
+all checks)</a></td>
 </tr>
 <tr class="even">
-<td align="left"><a href="https://codecheck.org.uk/register/codecheckers/0000-0003-3276-2141/">Hanne Oberman</a></td>
-<td align="left"><a href="https://orcid.org/0000-0003-3276-2141">0000-0003-3276-2141</a></td>
-<td align="left">NA <a href="https://codecheck.org.uk/register/codecheckers/0000-0003-3276-2141/">(see all checks)</a></td>
+<td align="left"><a
+href="https://codecheck.org.uk/register/codecheckers/0000-0003-3276-2141/">Hanne
+Oberman</a></td>
+<td align="left"><a
+href="https://orcid.org/0000-0003-3276-2141">0000-0003-3276-2141</a></td>
+<td align="left">1 <a
+href="https://codecheck.org.uk/register/codecheckers/0000-0003-3276-2141/">(see
+all checks)</a></td>
 </tr>
 <tr class="odd">
-<td align="left"><a href="https://codecheck.org.uk/register/codecheckers/0000-0003-0451-4052/">Veerle van Harten</a></td>
-<td align="left"><a href="https://orcid.org/0000-0003-0451-4052">0000-0003-0451-4052</a></td>
-<td align="left">NA <a href="https://codecheck.org.uk/register/codecheckers/0000-0003-0451-4052/">(see all checks)</a></td>
+<td align="left"><a
+href="https://codecheck.org.uk/register/codecheckers/0000-0003-0451-4052/">Veerle
+van Harten</a></td>
+<td align="left"><a
+href="https://orcid.org/0000-0003-0451-4052">0000-0003-0451-4052</a></td>
+<td align="left">1 <a
+href="https://codecheck.org.uk/register/codecheckers/0000-0003-0451-4052/">(see
+all checks)</a></td>
 </tr>
 <tr class="even">
-<td align="left"><a href="https://codecheck.org.uk/register/codecheckers/0000-0002-4062-5473/">Silvin Willemsen</a></td>
-<td align="left"><a href="https://orcid.org/0000-0002-4062-5473">0000-0002-4062-5473</a></td>
-<td align="left">NA <a href="https://codecheck.org.uk/register/codecheckers/0000-0002-4062-5473/">(see all checks)</a></td>
+<td align="left"><a
+href="https://codecheck.org.uk/register/codecheckers/0000-0002-4062-5473/">Silvin
+Willemsen</a></td>
+<td align="left"><a
+href="https://orcid.org/0000-0002-4062-5473">0000-0002-4062-5473</a></td>
+<td align="left">1 <a
+href="https://codecheck.org.uk/register/codecheckers/0000-0002-4062-5473/">(see
+all checks)</a></td>
 </tr>
 <tr class="odd">
-<td align="left"><a href="https://codecheck.org.uk/register/codecheckers/0000-0002-0097-1486/">Ilaria Fichera</a></td>
-<td align="left"><a href="https://orcid.org/0000-0002-0097-1486">0000-0002-0097-1486</a></td>
-<td align="left">NA <a href="https://codecheck.org.uk/register/codecheckers/0000-0002-0097-1486/">(see all checks)</a></td>
+<td align="left"><a
+href="https://codecheck.org.uk/register/codecheckers/0000-0002-0097-1486/">Ilaria
+Fichera</a></td>
+<td align="left"><a
+href="https://orcid.org/0000-0002-0097-1486">0000-0002-0097-1486</a></td>
+<td align="left">1 <a
+href="https://codecheck.org.uk/register/codecheckers/0000-0002-0097-1486/">(see
+all checks)</a></td>
 </tr>
 <tr class="even">
-<td align="left"><a href="https://codecheck.org.uk/register/codecheckers/0009-0000-6285-0316/">Andrea Gerbotto</a></td>
-<td align="left"><a href="https://orcid.org/0009-0000-6285-0316">0009-0000-6285-0316</a></td>
-<td align="left">NA <a href="https://codecheck.org.uk/register/codecheckers/0009-0000-6285-0316/">(see all checks)</a></td>
+<td align="left"><a
+href="https://codecheck.org.uk/register/codecheckers/0009-0000-6285-0316/">Andrea
+Gerbotto</a></td>
+<td align="left"><a
+href="https://orcid.org/0009-0000-6285-0316">0009-0000-6285-0316</a></td>
+<td align="left">1 <a
+href="https://codecheck.org.uk/register/codecheckers/0009-0000-6285-0316/">(see
+all checks)</a></td>
 </tr>
 <tr class="odd">
-<td align="left"><a href="https://codecheck.org.uk/register/codecheckers/0009-0009-6684-1930/">Jelle Langedijk</a></td>
-<td align="left"><a href="https://orcid.org/0009-0009-6684-1930">0009-0009-6684-1930</a></td>
-<td align="left">NA <a href="https://codecheck.org.uk/register/codecheckers/0009-0009-6684-1930/">(see all checks)</a></td>
+<td align="left"><a
+href="https://codecheck.org.uk/register/codecheckers/0009-0009-6684-1930/">Jelle
+Langedijk</a></td>
+<td align="left"><a
+href="https://orcid.org/0009-0009-6684-1930">0009-0009-6684-1930</a></td>
+<td align="left">1 <a
+href="https://codecheck.org.uk/register/codecheckers/0009-0009-6684-1930/">(see
+all checks)</a></td>
 </tr>
 <tr class="even">
-<td align="left"><a href="https://codecheck.org.uk/register/codecheckers/0009-0009-0918-9982/">Tim Schellekens</a></td>
-<td align="left"><a href="https://orcid.org/0009-0009-0918-9982">0009-0009-0918-9982</a></td>
-<td align="left">NA <a href="https://codecheck.org.uk/register/codecheckers/0009-0009-0918-9982/">(see all checks)</a></td>
+<td align="left"><a
+href="https://codecheck.org.uk/register/codecheckers/0009-0009-0918-9982/">Tim
+Schellekens</a></td>
+<td align="left"><a
+href="https://orcid.org/0009-0009-0918-9982">0009-0009-0918-9982</a></td>
+<td align="left">1 <a
+href="https://codecheck.org.uk/register/codecheckers/0009-0009-0918-9982/">(see
+all checks)</a></td>
 </tr>
 <tr class="odd">
-<td align="left"><a href="https://codecheck.org.uk/register/codecheckers/0009-0009-4474-171X/">João Fatela</a></td>
-<td align="left"><a href="https://orcid.org/0009-0009-4474-171X">0009-0009-4474-171X</a></td>
-<td align="left">NA <a href="https://codecheck.org.uk/register/codecheckers/0009-0009-4474-171X/">(see all checks)</a></td>
+<td align="left"><a
+href="https://codecheck.org.uk/register/codecheckers/0009-0009-4474-171X/">João
+Fatela</a></td>
+<td align="left"><a
+href="https://orcid.org/0009-0009-4474-171X">0009-0009-4474-171X</a></td>
+<td align="left">1 <a
+href="https://codecheck.org.uk/register/codecheckers/0009-0009-4474-171X/">(see
+all checks)</a></td>
 </tr>
 <tr class="even">
-<td align="left"><a href="https://codecheck.org.uk/register/codecheckers/0000-0003-3303-9297/">Simon Kersten</a></td>
-<td align="left"><a href="https://orcid.org/0000-0003-3303-9297">0000-0003-3303-9297</a></td>
-<td align="left">NA <a href="https://codecheck.org.uk/register/codecheckers/0000-0003-3303-9297/">(see all checks)</a></td>
+<td align="left"><a
+href="https://codecheck.org.uk/register/codecheckers/0000-0003-3303-9297/">Simon
+Kersten</a></td>
+<td align="left"><a
+href="https://orcid.org/0000-0003-3303-9297">0000-0003-3303-9297</a></td>
+<td align="left">1 <a
+href="https://codecheck.org.uk/register/codecheckers/0000-0003-3303-9297/">(see
+all checks)</a></td>
 </tr>
 </tbody>
 </table>
-<p><i>*Note that the total number of codechecks is less than the collective sum of individual codecheckers’ number of codechecks. This is because some codechecks involved more than one codechecker.</i></p>
+<p><i>*Note that the total number of codechecks is less than the
+collective sum of individual codecheckers’ number of codechecks. This is
+because some codechecks involved more than one codechecker.</i></p>
 
 <p style="margin-bottom: 2em;">
     <a

--- a/docs/codecheckers/index.json
+++ b/docs/codecheckers/index.json
@@ -1,167 +1,210 @@
 [
   {
     "Codechecker name": "Stephen J. Eglen",
-    "ORCID ID": "0000-0001-8607-8025"
+    "ORCID ID": "0000-0001-8607-8025",
+    "No. of codechecks": 16
   },
   {
     "Codechecker name": "Daniel Nüst",
-    "ORCID ID": "0000-0002-0024-5046"
+    "ORCID ID": "0000-0002-0024-5046",
+    "No. of codechecks": 20
   },
   {
     "Codechecker name": "Iain Davies",
-    "ORCID ID": "0000-0002-5361-6285"
+    "ORCID ID": "0000-0002-5361-6285",
+    "No. of codechecks": 5
   },
   {
     "Codechecker name": "Carlos Granell",
-    "ORCID ID": "0000-0003-1004-9695"
+    "ORCID ID": "0000-0003-1004-9695",
+    "No. of codechecks": 5
   },
   {
     "Codechecker name": "Frank Ostermann",
-    "ORCID ID": "0000-0002-9317-8291"
+    "ORCID ID": "0000-0002-9317-8291",
+    "No. of codechecks": 9
   },
   {
     "Codechecker name": "Marcel Stimberg",
-    "ORCID ID": "0000-0002-2648-4790"
+    "ORCID ID": "0000-0002-2648-4790",
+    "No. of codechecks": 1
   },
   {
     "Codechecker name": "Philipp A. Friese",
-    "ORCID ID": "0000-0002-3124-5364"
+    "ORCID ID": "0000-0002-3124-5364",
+    "No. of codechecks": 7
   },
   {
     "Codechecker name": "Anita Graser",
-    "ORCID ID": "0000-0001-5361-2885"
+    "ORCID ID": "0000-0001-5361-2885",
+    "No. of codechecks": 2
   },
   {
     "Codechecker name": "Jakub Krukar",
-    "ORCID ID": "0000-0003-2615-8757"
+    "ORCID ID": "0000-0003-2615-8757",
+    "No. of codechecks": 4
   },
   {
     "Codechecker name": "Alexander Kmoch",
-    "ORCID ID": "0000-0003-4386-4450"
+    "ORCID ID": "0000-0003-4386-4450",
+    "No. of codechecks": 2
   },
   {
     "Codechecker name": "Rémy Decoupes",
-    "ORCID ID": "0000-0003-0863-9581"
+    "ORCID ID": "0000-0003-0863-9581",
+    "No. of codechecks": 6
   },
   {
     "Codechecker name": "Eleni Tomai",
-    "ORCID ID": "0000-0003-1162-7389"
+    "ORCID ID": "0000-0003-1162-7389",
+    "No. of codechecks": 2
   },
   {
     "Codechecker name": "Eftychia Koukouraki",
-    "ORCID ID": "0000-0003-0928-1139"
+    "ORCID ID": "0000-0003-0928-1139",
+    "No. of codechecks": 5
   },
   {
     "Codechecker name": "Raniere Silva",
-    "ORCID ID": "0000-0002-8381-3749"
+    "ORCID ID": "0000-0002-8381-3749",
+    "No. of codechecks": 1
   },
   {
     "Codechecker name": "Nina Wiedemann",
-    "ORCID ID": "0000-0002-8160-7634"
+    "ORCID ID": "0000-0002-8160-7634",
+    "No. of codechecks": 2
   },
   {
     "Codechecker name": "Mehtab Alam Syed",
-    "ORCID ID": "0000-0003-3696-0030"
+    "ORCID ID": "0000-0003-3696-0030",
+    "No. of codechecks": 1
   },
-  {},
+  {
+    "No. of codechecks": 12
+  },
   {
     "Codechecker name": "Samuel Langton",
-    "ORCID ID": "0000-0002-1322-1553"
+    "ORCID ID": "0000-0002-1322-1553",
+    "No. of codechecks": 2
   },
   {
     "Codechecker name": "Lukas Röseler",
-    "ORCID ID": "0000-0002-6446-1901"
+    "ORCID ID": "0000-0002-6446-1901",
+    "No. of codechecks": 1
   },
   {
     "Codechecker name": "Patrick Eneche",
-    "ORCID ID": "0000-0002-0504-9677"
+    "ORCID ID": "0000-0002-0504-9677",
+    "No. of codechecks": 1
   },
   {
     "Codechecker name": "Amira Al Balushi",
-    "ORCID ID": "0009-0002-8188-6271"
+    "ORCID ID": "0009-0002-8188-6271",
+    "No. of codechecks": 1
   },
   {
     "Codechecker name": "Angelina Momin",
-    "ORCID ID": "0000-0002-6875-1551"
+    "ORCID ID": "0000-0002-6875-1551",
+    "No. of codechecks": 1
   },
   {
     "Codechecker name": "Jasper van Doninck",
-    "ORCID ID": "0000-0003-2177-7882"
+    "ORCID ID": "0000-0003-2177-7882",
+    "No. of codechecks": 1
   },
   {
     "Codechecker name": "Mareike Wendelmuth",
-    "ORCID ID": "0009-0008-5638-1670"
+    "ORCID ID": "0009-0008-5638-1670",
+    "No. of codechecks": 1
   },
   {
     "Codechecker name": "Yasel Quintero",
-    "ORCID ID": "0009-0005-9240-7370"
+    "ORCID ID": "0009-0005-9240-7370",
+    "No. of codechecks": 1
   },
   {
     "Codechecker name": "Joslyn Sun",
-    "ORCID ID": "0009-0002-2379-0060"
+    "ORCID ID": "0009-0002-2379-0060",
+    "No. of codechecks": 1
   },
   {
     "Codechecker name": "Roel Janssen",
-    "ORCID ID": "0000-0003-4324-5350"
+    "ORCID ID": "0000-0003-4324-5350",
+    "No. of codechecks": 1
   },
   {
     "Codechecker name": "Joey Tang",
-    "ORCID ID": "0000-0002-0820-6674"
+    "ORCID ID": "0000-0002-0820-6674",
+    "No. of codechecks": 1
   },
   {
     "Codechecker name": "Max Reichert",
-    "ORCID ID": "0009-0003-8352-7288"
+    "ORCID ID": "0009-0003-8352-7288",
+    "No. of codechecks": 1
   },
   {
     "Codechecker name": "Flora Zhou",
-    "ORCID ID": "0009-0002-4934-1474"
+    "ORCID ID": "0009-0002-4934-1474",
+    "No. of codechecks": 1
   },
   {
     "Codechecker name": "Eduard Klapwijk",
-    "ORCID ID": "0000-0002-8936-0365"
+    "ORCID ID": "0000-0002-8936-0365",
+    "No. of codechecks": 1
   },
   {
     "Codechecker name": "Tina Rozsos",
-    "ORCID ID": "0009-0008-5383-5497"
+    "ORCID ID": "0009-0008-5383-5497",
+    "No. of codechecks": 1
   },
   {
     "Codechecker name": "Stijn Peeters",
-    "ORCID ID": "0009-0004-3684-3584"
+    "ORCID ID": "0009-0004-3684-3584",
+    "No. of codechecks": 1
   },
   {
     "Codechecker name": "Hanne Oberman",
-    "ORCID ID": "0000-0003-3276-2141"
+    "ORCID ID": "0000-0003-3276-2141",
+    "No. of codechecks": 1
   },
   {
     "Codechecker name": "Veerle van Harten",
-    "ORCID ID": "0000-0003-0451-4052"
+    "ORCID ID": "0000-0003-0451-4052",
+    "No. of codechecks": 1
   },
   {
     "Codechecker name": "Silvin Willemsen",
-    "ORCID ID": "0000-0002-4062-5473"
+    "ORCID ID": "0000-0002-4062-5473",
+    "No. of codechecks": 1
   },
   {
     "Codechecker name": "Ilaria Fichera",
-    "ORCID ID": "0000-0002-0097-1486"
+    "ORCID ID": "0000-0002-0097-1486",
+    "No. of codechecks": 1
   },
   {
     "Codechecker name": "Andrea Gerbotto",
-    "ORCID ID": "0009-0000-6285-0316"
+    "ORCID ID": "0009-0000-6285-0316",
+    "No. of codechecks": 1
   },
   {
     "Codechecker name": "Jelle Langedijk",
-    "ORCID ID": "0009-0009-6684-1930"
+    "ORCID ID": "0009-0009-6684-1930",
+    "No. of codechecks": 1
   },
   {
     "Codechecker name": "Tim Schellekens",
-    "ORCID ID": "0009-0009-0918-9982"
+    "ORCID ID": "0009-0009-0918-9982",
+    "No. of codechecks": 1
   },
   {
     "Codechecker name": "João Fatela",
-    "ORCID ID": "0009-0009-4474-171X"
+    "ORCID ID": "0009-0009-4474-171X",
+    "No. of codechecks": 1
   },
   {
     "Codechecker name": "Simon Kersten",
-    "ORCID ID": "0000-0003-3303-9297"
+    "ORCID ID": "0000-0003-3303-9297",
+    "No. of codechecks": 1
   }
 ]


### PR DESCRIPTION
Related to this fix in the codecheck package: https://github.com/codecheckers/codecheck/pull/80

Fixed the issue where the no. codechecks column in "List of codecheckers" page was showing "NA" for all codecheckers.